### PR TITLE
add deprecation comment to core callback slugifier

### DIFF
--- a/CoreBundle/CallbackSlugifier.php
+++ b/CoreBundle/CallbackSlugifier.php
@@ -15,6 +15,8 @@ use Symfony\Cmf\Api\Slugifier\CallbackSlugifier as ApiCallbackSlugifier;
 
 /**
  * Slugifier service which uses a callback.
+ * 
+ * @deprecated Since 1.0, to be removed in 2.0. Use Symfony\Cmf\Api\Slugifier\CallbackSlugifier instead.
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */


### PR DESCRIPTION
imho trigger-error is not enough, the annotation will be used by IDEs to make people notice they should change.
